### PR TITLE
Allows specification of listen host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ docs/_build/
 
 # PyBuilder
 target/
+
+.idea/

--- a/tcprelay.py
+++ b/tcprelay.py
@@ -152,7 +152,9 @@ ports = []
 for arg in args:
     try:
         if ':' in arg:
-            rport, lport = arg.split(":")
+            rport, lport = arg.rsplit(":")
+            HOST, rport = rport.split(":") if len(rport.split(":")) > 1 else ("localhost", rport)
+            
             rport = int(rport)
             lport = int(lport)
             ports.append((rport, lport))

--- a/tcprelay.py
+++ b/tcprelay.py
@@ -89,13 +89,14 @@ class TCPRelay(SocketServer.BaseRequestHandler):
 
             while True:
                 mux.process(timeout = 1.0)
-                print "Devices:\n{0}".format("\n".join([available_dev for available_dev in mux.devices]))
+                print "Devices:\n{0}".format("\n".join([str(available_dev) for available_dev in mux.devices]))
 
                 #check if amount of devices from mux is the same as it was previously
                 if len(mux.devices) == lastLength:
                     #scan 3 more times just to make sure
                     for _ in xrange(3):
                         mux.process(timeout = 1.0)
+                        print "Last # of devices: {0} | Current # of devices: {1}".format(lastLength, len(mux.devices))
 
                     #if it's still the same, we can go ahead and stop the loop
                     if len(mux.devices) == lastLength:

--- a/tcprelay.py
+++ b/tcprelay.py
@@ -101,7 +101,7 @@ class TCPRelay(SocketServer.BaseRequestHandler):
                 index += 1
 
         if not dev:
-            raise Exception('Could not detect specified device udid')
+            raise Exception('Could not detect specified device udid: {0}'.format(repr(options.udid)))
 
         print "Connecting to device %s" % str(dev)
         dsock = mux.connect(dev, self.server.rport)

--- a/tcprelay.py
+++ b/tcprelay.py
@@ -85,9 +85,9 @@ class TCPRelay(SocketServer.BaseRequestHandler):
             # Default to the first available device if no udid was specified
             dev = mux.devices[0]
         else:
-            lastLength, hasAll = len(mux.devices), False
+            lastLength = len(mux.devices)
 
-            while not hasAll:
+            while True:
                 mux.process(timeout = 1.0)
                 print "Devices:\n{0}".format("\n".join([available_dev for available_dev in mux.devices]))
 
@@ -99,7 +99,9 @@ class TCPRelay(SocketServer.BaseRequestHandler):
 
                     #if it's still the same, we can go ahead and stop the loop
                     if len(mux.devices) == lastLength:
-                        hasAll = True
+                        break
+
+                lastLength = len(mux.devices)
 
             for available_dev in mux.devices:
                 # Look for the specified device UDID

--- a/tcprelay.py
+++ b/tcprelay.py
@@ -127,7 +127,7 @@ class ThreadedTCPServer(SocketServer.ThreadingMixIn, TCPServer):
 
 HOST = "localhost"
 
-parser = OptionParser(usage="usage: %prog [OPTIONS] RemotePort[:LocalPort] [RemotePort[:LocalPort]]...")
+parser = OptionParser(usage="usage: %prog [OPTIONS] [Host:]RemotePort[:LocalPort] [RemotePort[:LocalPort]]...")
 parser.add_option("-t", "--threaded", dest='threaded', action='store_true', default=False,
                   help="use threading to handle multiple connections at once")
 parser.add_option("-b", "--bufsize", dest='bufsize', action='store', metavar='KILOBYTES', type='int', default=128,
@@ -153,8 +153,7 @@ for arg in args:
     try:
         if ':' in arg:
             rport, lport = arg.rsplit(":")
-            HOST, rport = rport.split(":") if len(rport.split(":")) > 1 else ("localhost", rport)
-            
+            if len(rport.split(":")) > 1: HOST, rport = rport.split(":")
             rport = int(rport)
             lport = int(lport)
             ports.append((rport, lport))

--- a/tcprelay.py
+++ b/tcprelay.py
@@ -124,8 +124,6 @@ class ThreadedTCPServer(SocketServer.ThreadingMixIn, TCPServer):
     pass
 
 
-HOST = "localhost"
-
 parser = OptionParser(usage="usage: %prog [OPTIONS] [Host:]RemotePort[:LocalPort] [RemotePort[:LocalPort]]...")
 parser.add_option("-t", "--threaded", dest='threaded', action='store_true', default=False,
                   help="use threading to handle multiple connections at once")
@@ -152,21 +150,21 @@ for arg in args:
     try:
         if ':' in arg:
             rport, lport = arg.rsplit(":", 1)
-            if len(rport.split(":")) > 1: HOST, rport = rport.split(":")
+            host, rport = rport.split(":") if len(rport.split(":")) > 1 else ("localhost", rport)
             rport = int(rport)
             lport = int(lport)
-            ports.append((rport, lport))
+            ports.append((host, rport, lport))
         else:
-            ports.append((int(arg), int(arg)))
+            ports.append(("localhost", int(arg), int(arg)))
     except:
         parser.print_help()
         sys.exit(1)
 
 servers = []
 
-for rport, lport in ports:
-    print "Forwarding local port {0}:{1} to remote port {2}".format(HOST, lport, rport)
-    server = serverclass((HOST, lport), TCPRelay)
+for host, rport, lport in ports:
+    print "Forwarding local port {0}:{1} to remote port {2}".format(host, lport, rport)
+    server = serverclass((host, lport), TCPRelay)
     server.rport = rport
     server.bufsize = options.bufsize
     servers.append(server)

--- a/tcprelay.py
+++ b/tcprelay.py
@@ -24,7 +24,6 @@ import select
 from optparse import OptionParser
 import sys
 
-
 class SocketRelay(object):
     def __init__(self, a, b, maxbuf=65535):
         self.a = a
@@ -152,7 +151,7 @@ ports = []
 for arg in args:
     try:
         if ':' in arg:
-            rport, lport = arg.rsplit(":")
+            rport, lport = arg.rsplit(":", 1)
             if len(rport.split(":")) > 1: HOST, rport = rport.split(":")
             rport = int(rport)
             lport = int(lport)
@@ -166,7 +165,7 @@ for arg in args:
 servers = []
 
 for rport, lport in ports:
-    print "Forwarding local port %d to remote port %d" % (lport, rport)
+    print "Forwarding local port {0}:{1} to remote port {2}".format(HOST, lport, rport)
     server = serverclass((HOST, lport), TCPRelay)
     server.rport = rport
     server.bufsize = options.bufsize

--- a/tcprelay.py
+++ b/tcprelay.py
@@ -74,7 +74,7 @@ class TCPRelay(SocketServer.BaseRequestHandler):
         mux = usbmux.USBMux(options.sockpath)
         print "Waiting for devices..."
         if not mux.devices:
-            mux.process(1.0)
+            mux.process(0.1)
         if not mux.devices:
             print "No device found"
             self.request.close()
@@ -88,22 +88,14 @@ class TCPRelay(SocketServer.BaseRequestHandler):
             lastLength = len(mux.devices)
 
             while True:
-                mux.process(timeout = 1.0)
-                print "Devices:\n{0}".format("\n".join([str(available_dev) for available_dev in mux.devices]))
+                mux.process(timeout = 0.1)
 
                 #check if amount of devices from mux is the same as it was previously
-                if len(mux.devices) == lastLength:
-                    #scan 3 more times just to make sure
-                    for _ in xrange(3):
-                        mux.process(timeout = 1.0)
-                        print "Last # of devices: {0} | Current # of devices: {1}".format(lastLength, len(mux.devices))
-
-                    #if it's still the same, we can go ahead and stop the loop
-                    if len(mux.devices) == lastLength:
-                        break
+                if len(mux.devices) == lastLength: break
 
                 lastLength = len(mux.devices)
 
+            print "Devices:\n{0}".format("\n".join([str(available_dev) for available_dev in mux.devices]))
             for available_dev in mux.devices:
                 # Look for the specified device UDID
                 if available_dev.serial == options.udid:

--- a/tcprelay.py
+++ b/tcprelay.py
@@ -124,7 +124,7 @@ class ThreadedTCPServer(SocketServer.ThreadingMixIn, TCPServer):
     pass
 
 
-parser = OptionParser(usage="usage: %prog [OPTIONS] [Host:]RemotePort[:LocalPort] [RemotePort[:LocalPort]]...")
+parser = OptionParser(usage="usage: %prog [OPTIONS] [Host:]RemotePort[:LocalPort] [[Host:]RemotePort[:LocalPort]]...")
 parser.add_option("-t", "--threaded", dest='threaded', action='store_true', default=False,
                   help="use threading to handle multiple connections at once")
 parser.add_option("-b", "--bufsize", dest='bufsize', action='store', metavar='KILOBYTES', type='int', default=128,

--- a/usbmux.py
+++ b/usbmux.py
@@ -70,8 +70,7 @@ class MuxDevice(object):
         self.location = location
 
     def __str__(self):
-        return "<MuxDevice: ID %d ProdID 0x%04x Serial '%s' Location 0x%x>" % (
-            self.devid, self.usbprod, self.serial, self.location)
+        return "<MuxDevice: ID {0} ProdID 0x{1:04x} Serial '{2}' Location 0x{3:x}>".format(self.devid, self.usbprod, self.serial, self.location)
 
 
 class BinaryProtocol(object):


### PR DESCRIPTION
it also will let you specify the host to listen on for multiple, e.g.

`python tcprelay.py -tu 3c2b811fbe8bcef12dcf76a64d06a73efcb80585 0.0.0.0:8080:80 22:2222`

will cause remote port `8080` to listen on `0.0.0.0:80` and remote port `22` to listen on `localhost:2222`
